### PR TITLE
This will hopefully fix:http://bit.ly/1oUvQdi

### DIFF
--- a/src/sphinx/themes/plone/plone_basic/theme.conf
+++ b/src/sphinx/themes/plone/plone_basic/theme.conf
@@ -20,3 +20,4 @@ colophon = True
 sticky_navigation = False
 searchbox = True
 favicon = img/favicon.ico
+exclude_patterns = ['README.rst']


### PR DESCRIPTION
With this we should be able to rename README.txt to README.rst. If this works we should be able to close: https://github.com/plone/documentation/issues/72
