### PR TITLE
Removed opensearch, its had to be in the sphinx conf.py

### DIFF
--- a/src/sphinx/themes/plone/plone_org_4/theme.conf
+++ b/src/sphinx/themes/plone/plone_org_4/theme.conf
@@ -8,4 +8,3 @@ pygments_style = sphinx
 [options]
 logo = /img/plone.svg
 trademark_logo = /img/plone-invers.svg
-html_use_opensearch = True


### PR DESCRIPTION
Removing opensearch from here, its has to go to https://github.com/plone/documentation/conf.py where it is now
