### PR TITLE
Make current item bold

### DIFF
--- a/src/sphinx/themes/plone/plone_basic/static/css/ploneorg4.css
+++ b/src/sphinx/themes/plone/plone_basic/static/css/ploneorg4.css
@@ -280,6 +280,11 @@ blockquote {
     padding: 0;
     margin: 0 0 1em 0;
 }
+
+a .current .reference .internal {
+    font-weight: bold;
+}
+
 /*
 div.aside-toggle {
     height: 300px;


### PR DESCRIPTION
Bolds the link in the left navigation menu that the user is currently viewing—so user can quickly identify their place when navigating between multiple pages in the documentation.
