### PR TITLE
Add version_warning class to make it sticky for Plone 5.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 - Replaced link for chat button from Gitter to Discord [rohnsha0]
 - Changed broken link in Discord btn [rohnsha0]
 - Adapt links and version chooser for Plone 6 [polyester]
+- Add version_warning class to make it sticky for Plone 5.x [stevepiercy]
 
 
 0.5.8 (2019-10-26)

--- a/src/sphinxtheme/plone/plone_basic/static/css/ploneorg5.css
+++ b/src/sphinxtheme/plone/plone_basic/static/css/ploneorg5.css
@@ -114,3 +114,9 @@ a#floating-discord-btn {
   right: 10px;
   text-decoration: none;
 }
+div.version_warning {
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  z-index: 1001;
+}


### PR DESCRIPTION
Closes https://github.com/plone/documentation/issues/1473

Refs https://github.com/plone/documentation/pull/1474